### PR TITLE
Publish releases workflow #9

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,43 @@
+name: Build And Publish Releases
+
+# https://github.com/softprops/action-gh-release/issues/236#issuecomment-1150530128
+permissions:
+  contents: write
+
+on:
+  # Allow mannual trigger
+  workflow_dispatch:
+  # Trigger on push new tag
+  push:
+    tags:
+      - 'v*.*.*'
+
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Compile
+        uses: crazy-max/ghaction-xgo@v3
+        with:
+          xgo_version: latest
+          go_version: 1.21
+          dest: dist
+          prefix: clash2singbox
+          targets: windows/386,windows/amd64,linux/386,linux/amd64,darwin/arm64,darwin/amd64
+          # Show less information
+          v: false
+          x: false
+          race: false
+          ldflags: -s -w
+          buildmode: default
+
+      - name: Publish GitHub Releases
+        uses: softprops/action-gh-release@v1
+        with:
+          name: "clash2singbox ${{ github.ref_name }}" 
+          files: |
+            ./dist/*
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,7 @@ on:
   # Trigger on push new tag
   push:
     tags:
-      - 'v*.*.*'
-
+      - "v*.*.*"
 
 jobs:
   build-and-publish:
@@ -23,21 +22,22 @@ jobs:
         uses: crazy-max/ghaction-xgo@v3
         with:
           xgo_version: latest
-          go_version: 1.21
+          go_version: latest
           dest: dist
           prefix: clash2singbox
-          targets: windows/386,windows/amd64,linux/386,linux/amd64,darwin/arm64,darwin/amd64
+          targets: windows/386,windows/amd64,linux/386,linux/amd64,linux/arm,linux/arm64,darwin/arm64,darwin/amd64
           # Show less information
           v: false
           x: false
           race: false
           ldflags: -s -w
           buildmode: default
+          trimpath: true
 
       - name: Publish GitHub Releases
         uses: softprops/action-gh-release@v1
         with:
-          name: "clash2singbox ${{ github.ref_name }}" 
+          name: "clash2singbox ${{ github.ref_name }}"
           files: |
             ./dist/*
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
当 push 新 tag 且 tag 格式如 `v*.*.*` 时使用 Github Action 构建多平台可执行文件

使用示例

```shell
git tag -a "v0.0.1" -m "auto pack releases"
git push origin "v0.0.1"
```